### PR TITLE
Edited note info

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -19,6 +19,9 @@ webstrate.on("loaded", (webstrateId, clientId, user) => {
   initStatus.then( (endTime)=>{
     console.log("Initialization Completion Time: " + ((endTime-startTime)/1000) + " seconds");
     isInitialized = true;
+    
+    // Waiting on Promise initStatus to send Edited Note List
+    getElementsWithEditedNote()
   });
 });
 

--- a/src/links.js
+++ b/src/links.js
@@ -1,6 +1,6 @@
 var LINK_TEMPLATE = {
   'label': "Link Name",
-  'note': null,
+  'note': false,
   'reps': {
     'mapping':{
       'elements': {
@@ -38,7 +38,8 @@ function createLink(linkObj){
   		'id': generateObjectId(),
   		'class':'link',
   		sourceId : srcNode.id,
-  		targetId : targetNode.id
+  		targetId : targetNode.id,
+      note_edited: false
   	}).prependTo(snap);
   	link.line(srcPos.x, srcPos.y, destPos.x, destPos.y).attr({
   		'class': 'link-rep',
@@ -66,7 +67,7 @@ function linkToObject(link){
   return {
     'id': link.id,
     'label': getNodeLabel(link),
-    'note': null,
+    'note': link.getAttribute("note_edited"),
     'reps': {
       'mapping':{
         'elements': {

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -6,7 +6,7 @@
 {
   'id': String,
   'label': String,
-  'note': String - the id of the sticky note,
+  'note': Boolean - whether the sticky note is edited,
   'position': Point - contains x,y coordinates of node,
   'scale': [x,y] the amount of transformation on the object,
   'size': [x,y] the calculated size of the node,
@@ -38,7 +38,7 @@ var SHAPE_FUNCTIONS;
 
 var NODE_TEMPLATE = {
   'label': "Node Name",
-  'note': null,
+  'note': false,
   'position': {x: 50, y: 50},
   'scale': {x:1, y: 1},
   'groupId': null,
@@ -84,7 +84,7 @@ function initSnap(){
  *   'id': {string} the node's ID
  *   'type': {string} node/pin/link/image/etc,
  *   'label': {string} label,
- *   'note': {string} ID of any notes attached to this node,
+ *   'note': {boolean} whether the note attaching to this node is edited,
  *   'shape': {string} rectangle/circle,
  *   'position': [{float}, {float}] [centrx,centery],
  *   'scale': [{float}, {float}] [x,y],
@@ -145,6 +145,7 @@ function drawNode(nodeInfo){
       id: nodeInfo.id,
       class: "node" + (nodeInfo.reps.mapping.type !== "node" ? " " + nodeInfo.type : ""),
       shape: nodeInfo.shape,
+      note_edited: false,
     }).transform(Snap.matrix(1,0,0,1, nodeInfo.position.x, nodeInfo.position.y).toTransformString());
   
   if (nodeInfo.groupId) node.attr({'groupId': nodeInfo.groupId});
@@ -208,7 +209,7 @@ function nodeToObject(node){
   return {
     'id': node.id,
     'label': getNodeLabel(node),
-    'note': null,
+    'note': node.getAttribute("note_edited"),
     'position': getNodePosition(node),
     'scale': node.transformer.localScale,
     'size': [node.transformer.localScale.x * DEFAULT_NODE_SIZE[0], node.transformer.localScale.y * DEFAULT_NODE_SIZE[1] ],

--- a/src/request_handler.js
+++ b/src/request_handler.js
@@ -27,6 +27,17 @@ window.onmessage = function(e) {
   
 }
 
+// Dummy promise for sending 
+var promise1 = new Promise(function(resolve, reject) {
+  setTimeout(resolve, 10000, 'foo');
+});
+
+promise1.then(function(value) {
+  console.log("Sending edited elements to container!");
+  getElementsWithEditedNote()
+});
+
+
 // Message Passing to the Container Code. Package include the id & label
 function sendSearchMsgToContainer() {
   if (window.parent) {
@@ -97,15 +108,17 @@ function markElementAsNoteEdited(id) {
 // Send all the elements that has notes that are edited to container to load
 function getElementsWithEditedNote() {
   let elementList = getAllObjects(["node", "link"]);
+  //console.log(elementList)
   let editedElementList = elementList.filter(function(element) {
-    return element.note == true;
+    return element.note == "true";
   });
+  //console.log(editedElementList)
   
   let package = {
     id: "edited_elements",
     elements: editedElementList
   } 
-  
+
   if (window.parent) {
     window.parent.postMessage(package, "*")
   }

--- a/src/request_handler.js
+++ b/src/request_handler.js
@@ -85,7 +85,7 @@ function traceElementForContainer(id) {
 
 function markElementAsNoteEdited(id) {
   let editee = document.getElementById(id)
-  console.log("Prepare to Set: ", editee)
+  editee.setAttribute("note_edited", true)
 }
 
 

--- a/src/request_handler.js
+++ b/src/request_handler.js
@@ -1,7 +1,7 @@
 /* Handling Messages that have been post on the Webstrate */
 window.onmessage = function(e) {
   
-  //console.log("Handling Message");
+//  console.log("Handling Message");
   
   if (e.data.id == "search") {
     console.log("Message Type: Search");
@@ -14,6 +14,10 @@ window.onmessage = function(e) {
   else if (e.data.id == "edited") {
     console.log("Message Type: Edited");
     markElementAsNoteEdited(e.data.query)
+  }
+  else if (e.data.id == "reload_note_list") {
+    console.log("Message Type: Reload Note List!");
+    getElementsWithEditedNote()
   }
   else {
     // 400: Message does not have id in Header
@@ -71,6 +75,7 @@ function sendRelatedEleToContainer(label) {
   }
 }
 
+// Trace the related elements based on label received from container
 function traceElementForContainer(id) {
   let tracee = document.getElementById(id)
   if (tracee) {
@@ -83,9 +88,27 @@ function traceElementForContainer(id) {
   }   
 }
 
+// Mark elements' note as edited based on label received from container
 function markElementAsNoteEdited(id) {
   let editee = document.getElementById(id)
   editee.setAttribute("note_edited", true)
+}
+
+// Send all the elements that has notes that are edited to container to load
+function getElementsWithEditedNote() {
+  let elementList = getAllObjects(["node", "link"]);
+  let editedElementList = elementList.filter(function(element) {
+    return element.note == true;
+  });
+  
+  let package = {
+    id: "edited_elements",
+    elements: editedElementList
+  } 
+  
+  if (window.parent) {
+    window.parent.postMessage(package, "*")
+  }
 }
 
 

--- a/src/request_handler.js
+++ b/src/request_handler.js
@@ -29,7 +29,7 @@ window.onmessage = function(e) {
 
 // Dummy promise for sending 
 var promise1 = new Promise(function(resolve, reject) {
-  setTimeout(resolve, 10000, 'foo');
+  setTimeout(resolve, 8000, 'foo');
 });
 
 promise1.then(function(value) {
@@ -103,6 +103,7 @@ function traceElementForContainer(id) {
 function markElementAsNoteEdited(id) {
   let editee = document.getElementById(id)
   editee.setAttribute("note_edited", true)
+  getElementsWithEditedNote()
 }
 
 // Send all the elements that has notes that are edited to container to load

--- a/src/request_handler.js
+++ b/src/request_handler.js
@@ -9,20 +9,11 @@ window.onmessage = function(e) {
   } 
   else if (e.data.id == "trace") {
     console.log("Message Type: Trace");
-    let tracee = document.getElementById(e.data.query)
-    if (tracee) {
-      centerViewOnElement(tracee);
-      selectNode(tracee, true);
-    } 
-    else
-    {
-      console.log("204: Cannot find the element to trace")
-    }   
+    traceElementForContainer(e.data.query)   
   } 
   else if (e.data.id == "edited") {
     console.log("Message Type: Edited");
-    let editee = document.getElementById(e.data.query)
-    console.log("Prepare to Set: ", editee)
+    markElementAsNoteEdited(e.data.query)
   }
   else {
     // 400: Message does not have id in Header
@@ -80,7 +71,28 @@ function sendRelatedEleToContainer(label) {
   }
 }
 
-// Use The id of the Element to find the label of the element!
+function traceElementForContainer(id) {
+  let tracee = document.getElementById(id)
+  if (tracee) {
+    centerViewOnElement(tracee);
+    selectNode(tracee, true);
+  } 
+  else
+  {
+    console.log("204: Cannot find the element to trace")
+  }   
+}
+
+function markElementAsNoteEdited(id) {
+  let editee = document.getElementById(id)
+  console.log("Prepare to Set: ", editee)
+}
+
+
+// Helper Function to use The id of the Element to find its label
+/**
+* Applied to both node labels and node inputs
+**/
 function labelFinder(nodeID) {
   let labelElement = document.getElementById(nodeID+"_text");
   let labelText;

--- a/src/request_handler.js
+++ b/src/request_handler.js
@@ -27,15 +27,6 @@ window.onmessage = function(e) {
   
 }
 
-// Dummy promise for sending 
-var promise1 = new Promise(function(resolve, reject) {
-  setTimeout(resolve, 8000, 'foo');
-});
-
-promise1.then(function(value) {
-  getElementsWithEditedNote()
-});
-
 
 // Message Passing to the Container Code. Package include the id & label
 function sendSearchMsgToContainer() {

--- a/src/request_handler.js
+++ b/src/request_handler.js
@@ -22,7 +22,7 @@ window.onmessage = function(e) {
   else if (e.data.id == "edited") {
     console.log("Message Type: Edited");
     let editee = document.getElementById(e.data.query)
-    console.log(editee)
+    console.log("Prepare to Set: ", editee)
   }
   else {
     // 400: Message does not have id in Header

--- a/src/request_handler.js
+++ b/src/request_handler.js
@@ -33,7 +33,6 @@ var promise1 = new Promise(function(resolve, reject) {
 });
 
 promise1.then(function(value) {
-  console.log("Sending edited elements to container!");
   getElementsWithEditedNote()
 });
 
@@ -109,11 +108,9 @@ function markElementAsNoteEdited(id) {
 // Send all the elements that has notes that are edited to container to load
 function getElementsWithEditedNote() {
   let elementList = getAllObjects(["node", "link"]);
-  //console.log(elementList)
   let editedElementList = elementList.filter(function(element) {
     return element.note == "true";
   });
-  //console.log(editedElementList)
   
   let package = {
     id: "edited_elements",
@@ -136,10 +133,8 @@ function labelFinder(nodeID) {
   if (labelElement) {
     if (labelElement.getElementsByTagName("tspan")[0]) {
       labelText = labelElement.getElementsByTagName("tspan")[0].innerHTML;
-      //console.log("In View Mode, get label: " + labelText);
     } else {
       labelText = labelElement.innerHTML;
-      //console.log("In Edit Mode, get label: " + labelText);
     }
     return labelText;
   }

--- a/src/request_handler.js
+++ b/src/request_handler.js
@@ -17,9 +17,13 @@ window.onmessage = function(e) {
     else
     {
       console.log("204: Cannot find the element to trace")
-    }
-      
+    }   
   } 
+  else if (e.data.id == "edited") {
+    console.log("Message Type: Edited");
+    let editee = document.getElementById(e.data.query)
+    console.log(editee)
+  }
   else {
     // 400: Message does not have id in Header
     //console.log("400: Message type is not recognized")


### PR DESCRIPTION
Webstrate Mapping side of the Edit_Note_List functionality

Workflow:
Trigger: The Vue App send a edited note info package to the mapping -> 1. Mapping takes the id in the package to find the corresponding element -> 2. Setting the attribute of note in the html element as true -> 3. invoke a function that search for all the elements that has the attribute as true -> 4. form a package that sends back to the Vue App

To ensure webstrate mapping is the "leader server" in the "cluster" (Container App, Mapping, & Note Webstrates), everytime mapping webstrate's element got changes:
4. invoke the function to form the package that send this list back to container.