### PR TITLE
Bug fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,8 +84,8 @@
                 <span id="node_shape_container">
                     <button class="node_shape_button" id="rectangle_btn"></button>
                     <button class="node_shape_button" id="circle_btn"></button>
-                    <svg class="node_shape_button" id="triangle_btn">
-                        <polygon points="20,2 38,38, 2,38"></polygon>
+                    <svg class="node_shape_button" id="diamond_btn">
+                        <polygon points="20,2 38,20, 20,38, 2,20"></polygon>
                     </svg>
                 </span>
                 <span id="node_color_container">

--- a/index.html
+++ b/index.html
@@ -55,115 +55,119 @@
             <svg class="canvas transformable" id="canvas" style="width: 5760px; height: 3240px; z-index:0;" transform="matrix(1, 0, 0, 1, -2000, -1000)" xmlns="http://www.w3.org/2000/svg">
             </svg>
         </div>
-        <div id="content_container">
-            
-            <div id="toolSection" class="tabcontent">
-            <div onclick="showEdit()"><h1>
-                <svg id="editIcon" width="4vw" height="4vw" min-height="50px" min-width="50px" viewBox="0 0 45 47" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                   <!-- Generator: Sketch 50 (54983) - http://www.bohemiancoding.com/sketch width="45px" height="47px"-->
-                   <desc>Created with Sketch.</desc>
-                   <defs></defs>
-                   <g id="Hi-Fi-Prototypes" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-                       <g id="Toolbar---No-Tabs-Open" transform="translate(-32.000000, -118.000000)" fill="#4A4A4A">
-                           <path d="M75.8304635,154.029917 C76.5747227,152.693331 77,151.158499 77,149.526377 C77,144.339927 72.7284604,140.135777 67.4591952,140.135777 C63.8759497,140.135777 60.7572335,142.083692 59.1269878,144.958917 L44.1205148,137.591197 C44.2119164,137.17811 44.2604131,136.752153 44.2604131,136.313361 C44.2604131,135.421113 44.0589579,134.578403 43.706397,133.814653 L50.333866,128.110264 C51.2497451,128.73997 52.3614541,129.11268 53.5645601,129.11268 C56.6833241,129.11268 59.2107301,126.62497 59.2107301,123.5554 C59.208863,120.487569 56.6813663,118 53.5626501,118 C50.4439338,118 47.9164801,120.48771 47.9164801,123.55728 C47.9164801,124.743282 48.2970044,125.839369 48.9405169,126.740778 L42.6024237,132.195127 C41.4832176,131.018294 39.8958531,130.27842 38.1294194,130.27842 C34.743913,130.27842 32,132.98092 32,136.31322 C32,139.64552 34.7438648,142.34614 38.1294194,142.34614 C40.3696462,142.34614 42.3225983,141.160142 43.3916651,139.395809 L58.3456112,146.735799 C58.0676815,147.617049 57.9184572,148.553383 57.9184572,149.524591 C57.9184572,150.675715 58.1385643,151.775468 58.524666,152.794381 L50.2521484,156.115588 C49.2094406,154.45959 47.35161,153.354339 45.227229,153.354339 C41.961103,153.354339 39.3122165,155.961381 39.3122165,159.176228 C39.3122165,162.392816 41.9609598,165 45.227229,165 C48.493355,165 51.1422415,162.392957 51.1422415,159.178108 C51.1422415,158.739321 51.0900106,158.315235 50.9967466,157.905818 L59.398194,154.533192 C61.0881771,157.164111 64.0633038,158.915566 67.4582163,158.915566 C69.4447857,158.915566 71.2895323,158.317068 72.8173981,157.294442 C74.0708822,156.46461 75.1098653,155.342861 75.8317289,154.030152 L75.8304635,154.029917 Z" id="Page-1"></path>
-                       </g>
-                   </g>
-                </svg>
-                Edit
-            </h1></div>
-            <div id="edit">
 
-                <!-- Working color switch, leave here for now
-                <label class="switch">
-                  <input type="checkbox">
-                  <span class="slider round"></span>
-                </label>
-                -->
-
-                <h2>Node</h2>
-                <span id="node_shape_container">
-                    <button class="node_shape_button" id="rectangle_btn"></button>
-                    <button class="node_shape_button" id="circle_btn"></button>
-                    <svg class="node_shape_button" id="diamond_btn">
-                        <polygon points="20,2 38,20, 20,38, 2,20"></polygon>
-                    </svg>
-                </span>
-                <span id="node_color_container">
-                    <button class="node_color_button" id="green_node"></button>
-                    <button class="node_color_button" id="red_node"></button>
-                    <button class="node_color_button" id="blue_node"></button>
-                    <button class="node_color_button" id="black_node"></button>
-                </span>
-                <span id="node_border_container">
-                    <button class="node_color_button" id="green_border"></button>
-                    <button class="node_color_button" id="red_border"></button>
-                    <button class="node_color_button" id="blue_border"></button>
-                    <button class="node_color_button" id="black_border"></button>
-                </span>
-                <h2>Link</h2>
-                <span id="link_color_container">
-                    <button class="link_color_button" id="green_link"></button>
-                    <button class="link_color_button" id="red_link"></button>
-                    <button class="link_color_button" id="blue_link"></button>
-                    <button class="link_color_button" id="black_link"></button>
-                </span>
-                <span id="link_thickness_container">
-                    <!-- placeholder -->
-                </span>
-                <h2>Text</h2>
-                <span id="text_color_container">
-                    <button class="text_color_button" id="green_text">A</button>
-                    <button class="text_color_button" id="red_text">A</button>
-                    <button class="text_color_button" id="blue_text">A</button>
-                    <button class="text_color_button" id="black_text">A</button>
-                </span>
-                <br>
-                <h2>Font</h2>
-                <span id="label_edit_container">
-                    <button id="label_text_increase" style="font-weight: bold; vertical-align: top;">A↑</button>
-                    <button id="label_text_decrease" style="font-weight: bold; vertical-align: top;">A↓</button>
-                    <button id="label_text_bold" style="font-weight: bold; vertical-align: top;">B</button>
-                    <button id="label_text_italics" style="font-weight: italic; vertical-align: top;">I</button>
-                </span>
-              
-              <div id="minimap-wrapper">
-                <div id="minimap">
-                    <iframe id="minimap-bg" src="."></iframe>
-                    <div id="minimap-barrier"></div>
-                    <div id="minimap-placer"></div>
-                    </div>
-              </div>
-            </div>
-            <div onclick="showDraw()"><h1>
-                <svg id="drawIcon" width="4vw" height="4vw" min-height="50px" min-width="50px" viewBox="0 0 51 47" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-                   <!-- Generator: Sketch 50 (54983) - http://www.bohemiancoding.com/sketch -->
-                   <desc>Created with Sketch.</desc>
-                   <defs></defs>
-                   <g id="Hi-Fi-Prototypes" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-                       <g id="Toolbar---Condensed" transform="translate(-30.000000, -207.000000)" fill="#4A4A4A">
-                           <g id="Group-2" transform="translate(30.000000, 207.000000)">
-                               <path d="M45.792771,0.000340453745 C44.3814732,0.000340453745 43.0646667,0.552442943 42.0816166,1.55389279 L20.3310994,23.6823545 C20.3270747,23.6843714 20.3230552,23.6863832 20.3210429,23.6884001 C20.3170234,23.6904119 20.3170234,23.6944458 20.3150163,23.6984745 L15.4860741,28.6090039 C11.4532579,28.8125179 4.62419455,31.323194 3.65715035,40.0683674 C3.52647329,40.451218 2.89921209,42.0289683 1.43567638,42.2808525 C0.426481612,42.4561552 -0.0118017587,43.2117872 0.000241261163,43.88279 C0.0384387351,45.8675838 4.00289824,46.6131259 5.70575243,46.842829 C6.2887581,46.9214119 7.12909327,47 8.13226652,47 C12.4565856,47 19.7964974,45.506904 22.7336561,36.1147658 L49.5041569,8.88207711 C50.4791783,7.89269789 51.0099461,6.57689575 50.9998588,5.17850779 C50.9877952,3.78011983 50.4389835,2.47236478 49.4498604,1.49309601 C48.4688175,0.529921412 47.1720828,0 45.7929511,0 L45.792771,0.000340453745 Z M21.952974,26.9672131 L25.5,30.4512881 L22.0903701,33.9016393 L18.5454545,30.4175643 L21.952974,26.9672131 Z M12.6574258,43.2923318 C9.70081224,44.2197381 6.63616074,43.9594873 4.63636364,43.5134197 C5.99564274,42.2906018 6.46566501,40.6862732 6.49415911,40.5864503 C6.51450607,40.5140599 6.52874791,40.4397111 6.53688982,40.3653624 C7.3487891,32.7526774 13.7828278,31.7314086 15.7201135,31.5901639 L20.0909091,35.7320876 C18.7031375,39.6235776 16.2145667,42.1767497 12.6574414,43.2921816 L12.6574258,43.2923318 Z M47.2337623,7.13992655 L26.5419544,28.5081967 L23.1818182,25.1404697 L43.8756778,3.76802448 C44.7512583,2.86288032 46.320122,2.85270371 47.2097569,3.74152355 C47.6565697,4.19001455 47.9050406,4.79138431 47.9090415,5.43558978 C47.9130527,6.08183056 47.6726091,6.68726053 47.2338136,7.13983262 L47.2337623,7.13992655 Z" id="Page-1"></path>
-                               <polygon id="Path-4" points="15.8889972 30.2373029 21.9986954 35.9878518 15.8889972 43.1458777 6.38055401 46.1937934 3.04698287 44.7225293 6.38055401 38.2155482 6.38055401 35.9878518 12.5228391 30.2373029"></polygon>
-                               <polygon id="Path-5" points="21.8827533 24.5388004 26.4392065 30.0665132 50.1846427 5.6458871 46.0801138 0.883425483"></polygon>
+        <transient>
+            <div id="content_container"> 
+                <div id="toolSection" class="tabcontent">
+                    <div onclick="showEdit()">
+                        <h1>
+                        <svg id="editIcon" width="4vw" height="4vw" min-height="50px" min-width="50px" viewBox="0 0 45 47" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                           <!-- Generator: Sketch 50 (54983) - http://www.bohemiancoding.com/sketch width="45px" height="47px"-->
+                           <desc>Created with Sketch.</desc>
+                           <defs></defs>
+                           <g id="Hi-Fi-Prototypes" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                               <g id="Toolbar---No-Tabs-Open" transform="translate(-32.000000, -118.000000)" fill="#4A4A4A">
+                                   <path d="M75.8304635,154.029917 C76.5747227,152.693331 77,151.158499 77,149.526377 C77,144.339927 72.7284604,140.135777 67.4591952,140.135777 C63.8759497,140.135777 60.7572335,142.083692 59.1269878,144.958917 L44.1205148,137.591197 C44.2119164,137.17811 44.2604131,136.752153 44.2604131,136.313361 C44.2604131,135.421113 44.0589579,134.578403 43.706397,133.814653 L50.333866,128.110264 C51.2497451,128.73997 52.3614541,129.11268 53.5645601,129.11268 C56.6833241,129.11268 59.2107301,126.62497 59.2107301,123.5554 C59.208863,120.487569 56.6813663,118 53.5626501,118 C50.4439338,118 47.9164801,120.48771 47.9164801,123.55728 C47.9164801,124.743282 48.2970044,125.839369 48.9405169,126.740778 L42.6024237,132.195127 C41.4832176,131.018294 39.8958531,130.27842 38.1294194,130.27842 C34.743913,130.27842 32,132.98092 32,136.31322 C32,139.64552 34.7438648,142.34614 38.1294194,142.34614 C40.3696462,142.34614 42.3225983,141.160142 43.3916651,139.395809 L58.3456112,146.735799 C58.0676815,147.617049 57.9184572,148.553383 57.9184572,149.524591 C57.9184572,150.675715 58.1385643,151.775468 58.524666,152.794381 L50.2521484,156.115588 C49.2094406,154.45959 47.35161,153.354339 45.227229,153.354339 C41.961103,153.354339 39.3122165,155.961381 39.3122165,159.176228 C39.3122165,162.392816 41.9609598,165 45.227229,165 C48.493355,165 51.1422415,162.392957 51.1422415,159.178108 C51.1422415,158.739321 51.0900106,158.315235 50.9967466,157.905818 L59.398194,154.533192 C61.0881771,157.164111 64.0633038,158.915566 67.4582163,158.915566 C69.4447857,158.915566 71.2895323,158.317068 72.8173981,157.294442 C74.0708822,156.46461 75.1098653,155.342861 75.8317289,154.030152 L75.8304635,154.029917 Z" id="Page-1"></path>
+                               </g>
                            </g>
-                       </g>
-                   </g>
-                </svg>
-                Draw
-            </h1></div>
-            <div id="draw">
-                <span id="node_border_container">
-                  <button id="toggle_touch_drawing" onclick="toggleDrawFunc()"><div>
-                        <h4 style="font-size: 15px">Enable</h4>
-                    </div></button>
-                </span>
-            </div>
-            <button id="uploadImageBtn" class="toolbar">
-                <h5>Upload Image to Map</h5>
-            </button>
+                        </svg>
+                        Edit
+                        </h1>
+                    </div>
+                    <div id="edit">
 
-        </div>
-      </div>
+                        <!-- Working color switch, leave here for now
+                        <label class="switch">
+                          <input type="checkbox">
+                          <span class="slider round"></span>
+                        </label>
+                        -->
+
+                        <h2>Node</h2>
+                        <span id="node_shape_container">
+                            <button class="node_shape_button" id="rectangle_btn"></button>
+                            <button class="node_shape_button" id="circle_btn"></button>
+                            <svg class="node_shape_button" id="diamond_btn">
+                                <polygon points="20,2 38,20, 20,38, 2,20"></polygon>
+                            </svg>
+                        </span>
+                        <span id="node_color_container">
+                            <button class="node_color_button" id="green_node"></button>
+                            <button class="node_color_button" id="red_node"></button>
+                            <button class="node_color_button" id="blue_node"></button>
+                            <button class="node_color_button" id="black_node"></button>
+                        </span>
+                        <span id="node_border_container">
+                            <button class="node_color_button" id="green_border"></button>
+                            <button class="node_color_button" id="red_border"></button>
+                            <button class="node_color_button" id="blue_border"></button>
+                            <button class="node_color_button" id="black_border"></button>
+                        </span>
+                        <h2>Link</h2>
+                        <span id="link_color_container">
+                            <button class="link_color_button" id="green_link"></button>
+                            <button class="link_color_button" id="red_link"></button>
+                            <button class="link_color_button" id="blue_link"></button>
+                            <button class="link_color_button" id="black_link"></button>
+                        </span>
+                        <span id="link_thickness_container">
+                            <!-- placeholder -->
+                        </span>
+                        <h2>Text</h2>
+                        <span id="text_color_container">
+                            <button class="text_color_button" id="green_text">A</button>
+                            <button class="text_color_button" id="red_text">A</button>
+                            <button class="text_color_button" id="blue_text">A</button>
+                            <button class="text_color_button" id="black_text">A</button>
+                        </span>
+                        <br>
+                        <h2>Font</h2>
+                        <span id="label_edit_container">
+                            <button id="label_text_increase" style="font-weight: bold; vertical-align: top;">A↑</button>
+                            <button id="label_text_decrease" style="font-weight: bold; vertical-align: top;">A↓</button>
+                            <button id="label_text_bold" style="font-weight: bold; vertical-align: top;">B</button>
+                            <button id="label_text_italics" style="font-weight: italic; vertical-align: top;">I</button>
+                        </span>
+                      <div id="minimap-wrapper">
+                        <div id="minimap">
+                            <iframe id="minimap-bg" src="."></iframe>
+                            <div id="minimap-barrier"></div>
+                            <div id="minimap-placer"></div>
+                        </div>
+                      </div>
+                    </div>
+                    <div onclick="showDraw()">
+                        <h1>
+                        <svg id="drawIcon" width="4vw" height="4vw" min-height="50px" min-width="50px" viewBox="0 0 51 47" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                           <!-- Generator: Sketch 50 (54983) - http://www.bohemiancoding.com/sketch -->
+                           <desc>Created with Sketch.</desc>
+                           <defs></defs>
+                           <g id="Hi-Fi-Prototypes" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                               <g id="Toolbar---Condensed" transform="translate(-30.000000, -207.000000)" fill="#4A4A4A">
+                                   <g id="Group-2" transform="translate(30.000000, 207.000000)">
+                                       <path d="M45.792771,0.000340453745 C44.3814732,0.000340453745 43.0646667,0.552442943 42.0816166,1.55389279 L20.3310994,23.6823545 C20.3270747,23.6843714 20.3230552,23.6863832 20.3210429,23.6884001 C20.3170234,23.6904119 20.3170234,23.6944458 20.3150163,23.6984745 L15.4860741,28.6090039 C11.4532579,28.8125179 4.62419455,31.323194 3.65715035,40.0683674 C3.52647329,40.451218 2.89921209,42.0289683 1.43567638,42.2808525 C0.426481612,42.4561552 -0.0118017587,43.2117872 0.000241261163,43.88279 C0.0384387351,45.8675838 4.00289824,46.6131259 5.70575243,46.842829 C6.2887581,46.9214119 7.12909327,47 8.13226652,47 C12.4565856,47 19.7964974,45.506904 22.7336561,36.1147658 L49.5041569,8.88207711 C50.4791783,7.89269789 51.0099461,6.57689575 50.9998588,5.17850779 C50.9877952,3.78011983 50.4389835,2.47236478 49.4498604,1.49309601 C48.4688175,0.529921412 47.1720828,0 45.7929511,0 L45.792771,0.000340453745 Z M21.952974,26.9672131 L25.5,30.4512881 L22.0903701,33.9016393 L18.5454545,30.4175643 L21.952974,26.9672131 Z M12.6574258,43.2923318 C9.70081224,44.2197381 6.63616074,43.9594873 4.63636364,43.5134197 C5.99564274,42.2906018 6.46566501,40.6862732 6.49415911,40.5864503 C6.51450607,40.5140599 6.52874791,40.4397111 6.53688982,40.3653624 C7.3487891,32.7526774 13.7828278,31.7314086 15.7201135,31.5901639 L20.0909091,35.7320876 C18.7031375,39.6235776 16.2145667,42.1767497 12.6574414,43.2921816 L12.6574258,43.2923318 Z M47.2337623,7.13992655 L26.5419544,28.5081967 L23.1818182,25.1404697 L43.8756778,3.76802448 C44.7512583,2.86288032 46.320122,2.85270371 47.2097569,3.74152355 C47.6565697,4.19001455 47.9050406,4.79138431 47.9090415,5.43558978 C47.9130527,6.08183056 47.6726091,6.68726053 47.2338136,7.13983262 L47.2337623,7.13992655 Z" id="Page-1"></path>
+                                       <polygon id="Path-4" points="15.8889972 30.2373029 21.9986954 35.9878518 15.8889972 43.1458777 6.38055401 46.1937934 3.04698287 44.7225293 6.38055401 38.2155482 6.38055401 35.9878518 12.5228391 30.2373029"></polygon>
+                                       <polygon id="Path-5" points="21.8827533 24.5388004 26.4392065 30.0665132 50.1846427 5.6458871 46.0801138 0.883425483"></polygon>
+                                   </g>
+                               </g>
+                           </g>
+                        </svg>
+                        Draw
+                        </h1>
+                    </div>
+                    <div id="draw">
+                        <span id="node_border_container">
+                          <button id="toggle_touch_drawing" onclick="toggleDrawFunc()"><div>
+                                <h4 style="font-size: 15px">Enable</h4>
+                            </div></button>
+                        </span>
+                    </div>
+                    <button id="uploadImageBtn" class="toolbar">
+                        <h5>Upload Image to Map</h5>
+                    </button>
+                </div>
+            </div>
+        </transient>
     
 
     <div id="contextMenu" role="menu">

--- a/src/custom-style.js
+++ b/src/custom-style.js
@@ -2,7 +2,7 @@ $(document).ready(function() {
 
     $("#rectangle_btn").click(()=>setNodeShape("rectangle"));
     $("#circle_btn").click(()=>setNodeShape("circle"));
-    $("#triangle_btn").click(()=>setNodeShape("triangle"));
+    $("#diamond_btn").click(()=>setNodeShape("diamond"));
 
     $("#green_node").click(()=>setNodeColor("green"));
     $("#red_node").click(()=>setNodeColor("red"));

--- a/src/hammer_events.js
+++ b/src/hammer_events.js
@@ -174,6 +174,24 @@ function nodePanListener(event){
 	var deltaPoint = node.transformer.fromGlobalToLocalDelta(new Point(event.deltaX, event.deltaY));
 	var deltaDeltaPoint = new Point(deltaPoint.x - node.prevPoint.x, deltaPoint.y - node.prevPoint.y)
 
+	//Make sure a node isn't being moved outside its group
+	if(node.hasAttribute("groupId")){
+		let groupBB = document.getElementById( node.getAttribute("groupId") ).getBoundingClientRect();
+		let nodeBB = node.getBoundingClientRect();
+		let newBB = {};
+		newBB.left = nodeBB.left + deltaDeltaPoint.x;
+		newBB.right = nodeBB.right + deltaDeltaPoint.x;
+		newBB.top = nodeBB.top + deltaDeltaPoint.y;
+		newBB.bottom = nodeBB.bottom + deltaDeltaPoint.y;
+
+		if (newBB.left < groupBB.left || newBB.right > groupBB.right){
+			deltaDeltaPoint.x = 0;
+		}
+		if (newBB.top < groupBB.top || newBB.bottom > groupBB.bottom){
+			deltaDeltaPoint.y = 0;
+		}
+	}
+
 	translateNode(node, deltaDeltaPoint, true, node.links);
 
 	node.prevPoint.x = deltaPoint.x;

--- a/src/hammer_events.js
+++ b/src/hammer_events.js
@@ -281,7 +281,7 @@ function linkSingleTapListener(event){
 	var link = getParentMapElement(event.target);
 
 	if( $(link).hasClass("selected") ){
-		addLabel(null, link);
+		addLabel(null, link, true, true, true);
 	}else{
 		selectNode( link );
 		sendSearchMsgToContainer();

--- a/src/label.js
+++ b/src/label.js
@@ -42,7 +42,14 @@ function addLabel(text, node, requireInput=true, insertText=false, selectText=fa
  */
 function getNodeLabel(node){
   var label = node.getElementsByClassName("label")[0];
-  return label ? label.textContent : null;
+  if (!label) return null;
+
+  let labelText = "";
+  label.querySelectorAll(".label-line").forEach( (labelLine, index)=>{
+    labelText += (index > 0 ? "\n" : "") + labelLine.textContent;
+  });
+
+  return labelText;
 }
 
 

--- a/src/label.js
+++ b/src/label.js
@@ -225,6 +225,14 @@ function toggleListenersForLabelInput( isInputtingLabel ){
   //console.log("Toggling listeners for label input to: ", isInputtingLabel);
   toggleNonDrawingHammers( !isInputtingLabel )
   canvas.hammer.get( 'labelinputtap' ).set({ 'enable' : isInputtingLabel })
+
+  if( isInputtingLabel){ //Don't allow the user to navigate to other nodes with arrows
+    window.removeEventListener("keypress", keyPressListener);
+    window.removeEventListener("keydown", keyDownListener);
+  } else{
+    window.addEventListener("keypress", keyPressListener);
+    window.addEventListener("keydown", keyDownListener);
+  }
 }
 
 function handleClickDuringLabelInput(){

--- a/src/label.js
+++ b/src/label.js
@@ -7,16 +7,17 @@ const MIN_INPUT_COLS = 5;
  * Adds a label to a node either by user input (if placeholderText=true) or by
  * the text parameter
  * 
- * @param {String | Array} text-If placeholderText is true, this is the 
- * placeholder that appears in the background of the input div
- * @param {DOMELEMENT}  node-The Node to add the label to
+ * @param {String | Array} text  If placeholderText is true, this is the 
+ *                               placeholder that appears in the background of 
+ *                               the input div.  Otherwise, it is the label
+ * @param {DOMELEMENT}     node  The Node to add the label to
  * @param {Boolean} requireInput If true, user inputs label, if false,
  *                               inserts the text as a fully created label
- * @param {Boolean} insertText-If true and placeholderText is true, inserts
- *                             text into a newly created input div and places
- *                             the cursor at the end.
- * @param {Boolean} selectText-If true along with requireInput and insertText,
- *                             selects the inserted text so it will be replaced
+ * @param {Boolean}  insertText  If true and placeholderText is true, inserts 
+ *                               text into a newly created input div and places
+ *                               the cursor at the end.
+ * @param {Boolean} selectText   If true along with requireInput and insertText,
+ *                               selects the inserted text so it will be replaced
  */
 function addLabel(text, node, requireInput=true, insertText=false, selectText=false){
   
@@ -52,7 +53,22 @@ function getNodeLabel(node){
   return labelText;
 }
 
-
+/**
+ * Creates a temporary input element for the user to enter the label of a node.
+ * This is a transient element that only the current user can interact with.
+ * The label can be finalized by pressing Tab, Enter, or clicking outside the
+ * label.  Map-related event listeners are disabled during this time.
+ * 
+ * @param {SVGELEMENT}  node        The node to create a label for.
+ * @param {String}  placeholderText Text that will be preinserted.
+ * @param {Boolean} insertText      If false (default), laceholderText will be
+ *                                  inserted as transparent background text
+ *                                  that dissapears when the user types.  If
+ *                                  true, it is instead inserted as user input
+ * @param {Boolean} selectText      If this and insertText are true, the text
+ *                                  is selected so that the user can either
+ *                                  use the text as a label or replace it.
+ */
 function addLabelInputDiv(node, placeholderText, insertText=false, selectText=false){
   let label = node.getElementsByClassName("label")[0];
 
@@ -115,7 +131,12 @@ function addLabelInputDiv(node, placeholderText, insertText=false, selectText=fa
   labelInput.focus();
 }
 
-function drawLabel(node, labelText){
+/**
+ * Creates the label element on a node element
+ * @param  {SVGELEMENT}         node  The node to add the label to
+ * @param  {String | [String]}  labelText  The text to optionally put in the label
+ */
+function drawLabel(node, labelText=null){
   let cx, cy, textSVG;
 
   if (node.classList.contains("node")){
@@ -147,6 +168,12 @@ function drawLabel(node, labelText){
   }
 }
 
+/**
+ * Changes the label text of a node
+ * @param  {SVGELEMENT} node   The node classed element to change the text of
+ * @param  {String | [String]} - The text to insert to the label.  If an array
+ *                               of strings, each will have its own line
+ */
 function changeLabelText(node, labelLines){
   let label = node.querySelector(".label");
   label.innerHTML = " ";
@@ -175,8 +202,13 @@ function changeLabelText(node, labelLines){
   })
 }
 
+/**
+ * Deletes a temporary label-input element and inserts it's value into the appropriate node's label
+ * @param  {SVGELEMENT} node - The node to change the label of
+ * @param  {HTMLELEMENT} labelInput The label-input element to extract text from and delete
+ */
 function createLabelFromInput(node, labelInput){
-  let labelLines = labelInput.value.split('\n');//.filter((val)=>val);
+  let labelLines = labelInput.value.split('\n');
   changeLabelText(node, labelLines);
 
   // Remove the outside editable div
@@ -184,7 +216,6 @@ function createLabelFromInput(node, labelInput){
   temp_label_div = null;
   toggleListenersForLabelInput(false);
   sendSearchMsgToContainer();
-  return;
 }
 
 /* Blocks the user from interacting with other elements while a node is being edited
@@ -249,12 +280,9 @@ function handleClickDuringLabelInput(){
 }
 
 /**
- * Scale n
- * @param  {[type]} label [description]
- * @param  {[type]} node  [description]
- * @param  {[type]} cx    [description]
- * @param  {[type]} cy    [description]
- * @return {[type]}       [description]
+ * Changes the size of a node's representation to fit a label as it is being input by the user
+ * @label  {HTMLEMENT} label the label-input classed input element
+ * @param  {SVGELEMENT} node  the node-classed element whose representation will be scalled
  */
 function scaleNodeToLabelInput(label, node) {
   let nodeRep = node.getElementsByClassName(".node-rep")[0];

--- a/src/links.js
+++ b/src/links.js
@@ -39,7 +39,16 @@ function createLink(linkObj){
   		'class':'link',
   		sourceId : srcNode.id,
   		targetId : targetNode.id
-  	}).prependTo(snap);
+  	});
+    //Insert the link after any groups or images
+    var groups = canvas.getElementsByClassName("group");
+    if( groups.length > 0 ) {
+      link.insertAfter(groups[groups.length-1])
+    }
+    else{
+      link.prependTo(canvas);
+    }
+
   	link.line(srcPos.x, srcPos.y, destPos.x, destPos.y).attr({
   		'class': 'link-rep',
   		"xmlns": "http://www.w3.org/2000/svg"

--- a/src/main.js
+++ b/src/main.js
@@ -33,8 +33,8 @@ var zoom = null;
 
 var quickAddDist = 10 + MAX_RADIUS;
 
-window.addEventListener("keypress", (e) => keyPressListener(e));
-window.addEventListener("keydown", (e) => keyDownListener(e));
+window.addEventListener("keypress", keyPressListener);
+window.addEventListener("keydown", keyDownListener);
 
 function mouseOverListener(e) {
   if (drawing_enabled) return;

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -54,7 +54,7 @@ var NODE_TEMPLATE = {
       'elements': {
         'node' : {
           'shape': "rectangle",
-          'repSize': DEFAULT_NODE_SIZE,
+          'repSize': DEFAULT_SHAPE_SIZES['rectangle'],
           'style': {
             'node-rep':{
               'fill': 'rgba(46, 127, 195, 0.1)',

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -138,7 +138,6 @@ function changeShapeSize(node, width, height){
  */
 function createNode(nodeInfo={}){
   //Merge the input node info with defaults, and gives it a unique ID
-  console.log(nodeInfo)
   return new Promise((resolve, reject)=>{
     nodeInfo = Object.assign( {},
       NODE_TEMPLATE, 
@@ -201,9 +200,10 @@ function drawNode(nodeInfo){
 function drawNodeRep(node, nodeInfo=NODE_TEMPLATE){
   node = node instanceof SVGElement ? Snap(node): node;
   var shape = nodeInfo.reps.mapping.elements.node.shape;
-  var shapeInfo = SHAPE_FUNCTIONS[shape];
 
-  var nodeRep = shapeInfo.function.call(node, ...shapeInfo.args).attr({
+  let shapeEle = createShape(shape);
+
+  var nodeRep = Snap(shapeEle).attr({
     class: "node-rep",
     "z-index": 1,
     "xmlns": "http://www.w3.org/2000/svg"

--- a/styles/sidebar.css
+++ b/styles/sidebar.css
@@ -43,12 +43,12 @@
 #circle_btn{
   border-radius: 50%;
 }
-#triangle_btn{
+#diamond_btn{
   vertical-align: bottom;
   margin: 2px;
   background-color: transparent;
 }
-#triangle_btn polygon{
+#diamond_btn polygon{
   stroke: blue;
   stroke-width: 4px;
   fill: rgba(46, 127, 195, 0.5);


### PR DESCRIPTION
Various fixes.  Multi-line label now works as intended and automatically resizes the node representation.  The triangle option for node shape was changed to a diamond.  The sidebar is now transient to avoid syncing with webstrates and avoid multi-user issues.  Arrow keys can no longer change the selected node during label input, and nodes can no longer be moved outside of groups or images they are a part of.